### PR TITLE
Add class btn--send to proper button

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -63,7 +63,7 @@
                                 <i class="fa fa-file text-white"></i>
                                 <input id="input_file" type = "file"  onchange = "readThensend()" hidden/>
                             </label>
-                            <button id="button-addon4" type="submit" class="btn btn-link text-custom shadow-none"><i class="fa fa-send"></i></button>
+                            <button id="button-addon4" type="submit" class="btn btn-link text-custom shadow-none btn--send"><i class="fa fa-send"></i></button>
                           </div>
                     </form>
                 </div>


### PR DESCRIPTION
I have assigned class btn--send to proper button, so that `sendButton` variable is not null anymore. 

![image](https://user-images.githubusercontent.com/89598954/198280022-fa116c4d-b174-44db-8851-9b707583603d.png)

However, the other issues came up. EventListener attached to `sendButton`  changes button permanently. Button doesn't come back to it's original state. There is also text 'send' left, along with not working icon. It also seems not to send message after first click. It just changes the look of the button, the second click sends the message (if the user didn't click on the icon - in that case message won't be sent either). 
There is also difference in the look of the button whether the user sends message by clicking on the button or pressing enter key. 
I hope screenshots explains this well. I think another issue should be opened for problems described above. 

![image](https://user-images.githubusercontent.com/89598954/198280962-fa602b38-b38c-47d3-91dc-8f88ca8cd3b0.png)

